### PR TITLE
Enable aarch64 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ task removeUnsupported(type: Delete) {
   dependsOn extractRelease
   delete "${jarDir}/${pkgDir}/aix-ppc"
   delete "${jarDir}/${pkgDir}/aix-ppc64"
+  delete "${jarDir}/${pkgDir}/linux-arm"
   delete "${jarDir}/${pkgDir}/linux-armel"
   delete "${jarDir}/${pkgDir}/linux-ppc"
   delete "${jarDir}/${pkgDir}/linux-ppc64le"

--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,6 @@ task removeUnsupported(type: Delete) {
   dependsOn extractRelease
   delete "${jarDir}/${pkgDir}/aix-ppc"
   delete "${jarDir}/${pkgDir}/aix-ppc64"
-  delete "${jarDir}/${pkgDir}/linux-aarch64"
-  delete "${jarDir}/${pkgDir}/linux-arm"
   delete "${jarDir}/${pkgDir}/linux-armel"
   delete "${jarDir}/${pkgDir}/linux-ppc"
   delete "${jarDir}/${pkgDir}/linux-ppc64le"


### PR DESCRIPTION
To make progress in our ARM testing efforts (elastic/infra#1588), we need to remove the disabling of `aarch64` here so we can get the appropriate `libjnidispatch.so` in the `jna.jar`.

I've tested this patch and it does indeed make `com.sun.jna.Native` available and usable on our test machine.