### PR TITLE
Add local version extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .gradle
 .vagrant
 build
-/tmp
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gradle
 .vagrant
 build
+/tmp

--- a/README.md
+++ b/README.md
@@ -28,18 +28,15 @@ Ensure you have the OSSRH Sonatype staging environment set up in
 
 Then build:
 
-    % vagrant up
-    % gradle assemble generatePomFileForJnaPublication
-    % vagrant halt
+    % vagrant up && gradle assemble && vagrant halt
 
 In order for OSSRH to accept the package, it must have sources and
 javadoc jars as well.  We don't have any automation here to build
 them, so simply reuse from net.java.dev/jna:
 
-    % mkdir -p tmp
-    % curl -L -o tmp/jna-${VERSION}-sources.jar \
+    % curl -L -o build/jna-${VERSION}-sources.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-sources.jar
-    % curl -L -o tmp/jna-${VERSION}-javadoc.jar \
+    % curl -L -o build/jna-${VERSION}-javadoc.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-javadoc.jar
 
 Now upload to OSSRH, signing with the Elasticsearch key (it will
@@ -55,8 +52,8 @@ but please try to avoid):
         -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
         -DpomFile=build/distributions/jna-${VERSION}.pom \
         -Dfile=build/distributions/jna-${VERSION}.jar \
-        -Dsources=tmp/jna-${VERSION}-sources.jar \
-        -Djavadoc=tmp/jna-${VERSION}-javadoc.jar \
+        -Dsources=build/jna-${VERSION}-sources.jar \
+        -Djavadoc=build/jna-${VERSION}-javadoc.jar \
         -Dgpg.keyname=D88E42B4
 
 
@@ -79,18 +76,15 @@ Set shell variables for convenience:
 Then build the artifact and pom as usual, but supply `version.suffix`
 property:
 
-    % vagrant up
-    % gradle assemble generatePomFileForJnaPublication -Dversion.suffix=$SUFFIX
-    % vagrant halt
+    % vagrant up && gradle assemble -Dversion.suffix=$SUFFIX && vagrant halt
 
 In order for OSSRH to accept the package, it must have sources and
 javadoc jars as well.  We don't have any automation here to build
 them, so simply reuse from upstream net.java.dev/jna:
 
-    % mkdir -p tmp
-    % curl -L -o tmp/jna-${VERSION}${SUFFIX}-sources.jar \
+    % curl -L -o build/jna-${VERSION}${SUFFIX}-sources.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-sources.jar
-    % curl -L -o tmp/jna-${VERSION}${SUFFIX}-javadoc.jar \
+    % curl -L -o build/jna-${VERSION}${SUFFIX}-javadoc.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-javadoc.jar
 
 Now upload to OSSRH, signing with the Elasticsearch key:
@@ -104,8 +98,8 @@ Now upload to OSSRH, signing with the Elasticsearch key:
       -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
       -DpomFile=build/distributions/jna-${VERSION}${SUFFIX}.pom \
       -Dfile=build/distributions/jna-${VERSION}${SUFFIX}.jar \
-      -Dsources=tmp/jna-${VERSION}${SUFFIX}-sources.jar \
-      -Djavadoc=tmp/jna-${VERSION}${SUFFIX}-javadoc.jar \
+      -Dsources=build/jna-${VERSION}${SUFFIX}-sources.jar \
+      -Djavadoc=build/jna-${VERSION}${SUFFIX}-javadoc.jar \
       -Dgpg.keyname=D88E42B4
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First set shell variables for convenience:
     export VERSION=4.4.0
 
 Ensure you have the OSSRH Sonatype staging environment set up in
-~/.m2/settings.xml:
+`~/.m2/settings.xml`:
 
     <server>
       <id>sonatype-nexus-staging</id>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Elasticsearch JNA Build
+=======================
+
 This project exists in order to build a jna jar which supports
 platforms supported by elastic.  It builds native linux bits for jna
 in vagrant, and uses the provided native bits for mac and windows.

--- a/README.txt
+++ b/README.txt
@@ -4,9 +4,10 @@ It builds native linux bits for jna in vagrant, and uses the provided native bit
 Publish to Maven Central
 ------------------------
 
-First set a shell variable for convenience:
+First set shell variables for convenience:
 
-    export PRERELEASE=2 # or whatever ordinal makes sense
+    export VERSION=4.4.0  # match whatever's in build.gradle
+    export PRERELEASE=2   # or whatever ordinal makes sense
 
 Ensure you have the OSSRH Sonatype staging environment set up in
 ~/.m2/settings.xml:
@@ -27,10 +28,10 @@ In order for OSSRH to accept the package, it must have sources and
 javadoc jars as well.  We don't have any automation here to build
 them, so simply reuse the upstream net.java.dev/jna ones:
 
-    curl -L -o target/jna-4.4.0-${PRERELEASE}-sources.jar \
-      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/4.4.0/jna-4.4.0-sources.jar
-    curl -L -o target/jna-4.4.0-${PRERELEASE}-javadoc.jar \
-      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/4.4.0/jna-4.4.0-javadoc.jar
+    curl -L -o target/jna-${VERSION}-${PRERELEASE}-sources.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-sources.jar
+    curl -L -o target/jna-${VERSION}-${PRERELEASE}-javadoc.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-javadoc.jar
 
 Now upload to OSSRH, signing with the Elasticsearch key (it will
 prompt for passphrase):
@@ -42,8 +43,8 @@ prompt for passphrase):
       -Dpackaging=jar \
       -DrepositoryId=sonatype-nexus-staging \
       -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
-      -DpomFile=build/distributions/jna-4.4.0-${PRERELEASE}.pom \
-      -Dfile=build/distributions/jna-4.4.0-${PRERELEASE}.jar \
-      -Dsources=target/jna-4.4.0-${PRERELEASE}-sources.jar \
-      -Djavadoc=target/jna-4.4.0-${PRERELEASE}-javadoc.jar \
+      -DpomFile=build/distributions/jna-${VERSION}-${PRERELEASE}.pom \
+      -Dfile=build/distributions/jna-${VERSION}-${PRERELEASE}.jar \
+      -Dsources=target/jna-${VERSION}-${PRERELEASE}-sources.jar \
+      -Djavadoc=target/jna-${VERSION}-${PRERELEASE}-javadoc.jar \
       -Dgpg.keyname=D88E42B4

--- a/README.txt
+++ b/README.txt
@@ -1,13 +1,18 @@
-This project exists in order to build a jna jar which supports platforms supported by elastic.
-It builds native linux bits for jna in vagrant, and uses the provided native bits for mac and windows.
+This project exists in order to build a jna jar which supports
+platforms supported by elastic.  It builds native linux bits for jna
+in vagrant, and uses the provided native bits for mac and windows.
 
-Publish to Maven Central
-------------------------
+
+Publish to Maven Central (Normal case)
+--------------------------------------
+
+In the default case, we track with upstream JNA.  This is when the
+local version exactly matches net.java.dev/jna.
 
 First set shell variables for convenience:
 
-    export VERSION=4.4.0  # match whatever's in build.gradle
-    export PRERELEASE=2   # or whatever ordinal makes sense
+    # match whatever's in build.gradle
+    export VERSION=4.4.0
 
 Ensure you have the OSSRH Sonatype staging environment set up in
 ~/.m2/settings.xml:
@@ -18,23 +23,74 @@ Ensure you have the OSSRH Sonatype staging environment set up in
       <password>pass</password>
     </server>
 
-Then build the artifact and pom:
+Then build:
 
     % vagrant up
-    % gradle assemble generatePomFileForJnaPublication -Dprerelease=$PRERELEASE
+    % gradle assemble generatePomFileForJnaPublication
     % vagrant halt
 
 In order for OSSRH to accept the package, it must have sources and
 javadoc jars as well.  We don't have any automation here to build
-them, so simply reuse the upstream net.java.dev/jna ones:
+them, so simply reuse from net.java.dev/jna:
 
-    curl -L -o target/jna-${VERSION}-${PRERELEASE}-sources.jar \
+    % mkdir -p tmp
+    % curl -L -o tmp/jna-${VERSION}-sources.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-sources.jar
-    curl -L -o target/jna-${VERSION}-${PRERELEASE}-javadoc.jar \
+    % curl -L -o tmp/jna-${VERSION}-javadoc.jar \
       https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-javadoc.jar
 
 Now upload to OSSRH, signing with the Elasticsearch key (it will
-prompt for passphrase):
+prompt for passphrase, or if desperate you can use -Dgpg.passphrase
+but please try to avoid):
+
+    % mvn gpg:sign-and-deploy-file \
+        -DgroupId=org.elasticsearch \
+        -DartifactId=jna \
+        -DgeneratePom=false \
+        -Dpackaging=jar \
+        -DrepositoryId=sonatype-nexus-staging \
+        -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
+        -DpomFile=build/distributions/jna-${VERSION}.pom \
+        -Dfile=build/distributions/jna-${VERSION}.jar \
+        -Dsources=tmp/jna-${VERSION}-sources.jar \
+        -Djavadoc=tmp/jna-${VERSION}-javadoc.jar \
+        -Dgpg.keyname=D88E42B4
+
+
+Publish to Maven Central (With only local modifications)
+--------------------------------------------------------
+
+Sometimes we may need to publish a jar that has local modifications
+when there hasn't been an upstream release.  See for example
+[4.4.0-1][example-release].  The instructions are almost identical,
+but we introduce a `suffix`.
+
+Set shell variables for convenience:
+
+    # Match whatever's in build.gradle
+    export VERSION=4.4.0
+
+    # Start at 1, but this may be incremented to whatever makes sense
+    export SUFFIX="-2"
+
+Then build the artifact and pom as usual, but supply `version.suffix`
+property:
+
+    % vagrant up
+    % gradle assemble generatePomFileForJnaPublication -Dversion.suffix=$SUFFIX
+    % vagrant halt
+
+In order for OSSRH to accept the package, it must have sources and
+javadoc jars as well.  We don't have any automation here to build
+them, so simply reuse from upstream net.java.dev/jna:
+
+    % mkdir -p tmp
+    % curl -L -o tmp/jna-${VERSION}${SUFFIX}-sources.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-sources.jar
+    % curl -L -o tmp/jna-${VERSION}${SUFFIX}-javadoc.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/${VERSION}/jna-${VERSION}-javadoc.jar
+
+Now upload to OSSRH, signing with the Elasticsearch key:
 
     mvn gpg:sign-and-deploy-file \
       -DgroupId=org.elasticsearch \
@@ -43,8 +99,11 @@ prompt for passphrase):
       -Dpackaging=jar \
       -DrepositoryId=sonatype-nexus-staging \
       -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
-      -DpomFile=build/distributions/jna-${VERSION}-${PRERELEASE}.pom \
-      -Dfile=build/distributions/jna-${VERSION}-${PRERELEASE}.jar \
-      -Dsources=target/jna-${VERSION}-${PRERELEASE}-sources.jar \
-      -Djavadoc=target/jna-${VERSION}-${PRERELEASE}-javadoc.jar \
+      -DpomFile=build/distributions/jna-${VERSION}${SUFFIX}.pom \
+      -Dfile=build/distributions/jna-${VERSION}${SUFFIX}.jar \
+      -Dsources=tmp/jna-${VERSION}${SUFFIX}-sources.jar \
+      -Djavadoc=tmp/jna-${VERSION}${SUFFIX}-javadoc.jar \
       -Dgpg.keyname=D88E42B4
+
+
+[example-release]: http://search.maven.org/#artifactdetails%7Corg.elasticsearch%7Cjna%7C4.4.0-1%7Cjar

--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,49 @@
 This project exists in order to build a jna jar which supports platforms supported by elastic.
 It builds native linux bits for jna in vagrant, and uses the provided native bits for mac and windows.
+
+Publish to Maven Central
+------------------------
+
+First set a shell variable for convenience:
+
+    export PRERELEASE=2 # or whatever ordinal makes sense
+
+Ensure you have the OSSRH Sonatype staging environment set up in
+~/.m2/settings.xml:
+
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>user</username>
+      <password>pass</password>
+    </server>
+
+Then build the artifact and pom:
+
+    % vagrant up
+    % gradle assemble generatePomFileForJnaPublication -Dprerelease=$PRERELEASE
+    % vagrant halt
+
+In order for OSSRH to accept the package, it must have sources and
+javadoc jars as well.  We don't have any automation here to build
+them, so simply reuse the upstream net.java.dev/jna ones:
+
+    curl -L -o target/jna-4.4.0-${PRERELEASE}-sources.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/4.4.0/jna-4.4.0-sources.jar
+    curl -L -o target/jna-4.4.0-${PRERELEASE}-javadoc.jar \
+      https://oss.sonatype.org/content/repositories/releases/net/java/dev/jna/jna/4.4.0/jna-4.4.0-javadoc.jar
+
+Now upload to OSSRH, signing with the Elasticsearch key (it will
+prompt for passphrase):
+
+    mvn gpg:sign-and-deploy-file \
+      -DgroupId=org.elasticsearch \
+      -DartifactId=jna \
+      -DgeneratePom=false \
+      -Dpackaging=jar \
+      -DrepositoryId=sonatype-nexus-staging \
+      -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
+      -DpomFile=build/distributions/jna-4.4.0-${PRERELEASE}.pom \
+      -Dfile=build/distributions/jna-4.4.0-${PRERELEASE}.jar \
+      -Dsources=target/jna-4.4.0-${PRERELEASE}-sources.jar \
+      -Djavadoc=target/jna-4.4.0-${PRERELEASE}-javadoc.jar \
+      -Dgpg.keyname=D88E42B4

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,13 @@ apply plugin: 'maven-publish'
 group = 'org.elasticsearch'
 String upstreamVersion = '4.4.0'
 
-if (System.getProperty("prerelease") != null) {
-  String localPrerelease = System.getProperty("prerelease")
-  version = "${upstreamVersion}-${localPrerelease}"
+// Rarely, modifications may need to be made to the jna jar that
+// aren't reflected in the upstream.  A suffix can be supplied to bump
+// the local version.  See readme for details.
+String versionSuffix = System.getProperty("version.suffix")
+
+if (versionSuffix != null) {
+  version = "${upstreamVersion}${versionSuffix}"
 } else {
   version = upstreamVersion
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,9 @@
 apply plugin: 'maven-publish'
 
 group = 'org.elasticsearch'
-version = '4.4.0'
+String upstreamVersion = '4.4.0'
+String localPrerelease = '1'
+version = "${upstreamVersion}-${localPrerelease}"
 String jnaDir = 'build/jna'
 String jarDir = 'build/jar'
 String pkgDir = 'com/sun/jna'
@@ -38,7 +40,7 @@ configurations {
   jna
 }
 dependencies {
-   jna "net.java.dev.jna:jna:${version}"
+   jna "net.java.dev.jna:jna:${upstreamVersion}"
 }
 
 task clean(type: Delete) {
@@ -70,7 +72,7 @@ task checkoutJna(type: LoggedExec) {
   doFirst {
     file(jnaDir).parentFile.mkdirs()
   }
-  commandLine 'git', 'clone', '-b', version, 'https://github.com/java-native-access/jna', jnaDir
+  commandLine 'git', 'clone', '-b', upstreamVersion, 'https://github.com/java-native-access/jna', jnaDir
 }
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,9 @@ String upstreamVersion = '4.4.0'
 // Rarely, modifications may need to be made to the jna jar that
 // aren't reflected in the upstream.  A suffix can be supplied to bump
 // the local version.  See readme for details.
-String versionSuffix = System.getProperty("version.suffix")
+String versionSuffix = System.getProperty("version.suffix", "")
 
-if (versionSuffix != null) {
-  version = "${upstreamVersion}${versionSuffix}"
-} else {
-  version = upstreamVersion
-}
+version = "${upstreamVersion}${versionSuffix}"
 
 String jnaDir = 'build/jna'
 String jarDir = 'build/jar'

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,14 @@ apply plugin: 'maven-publish'
 
 group = 'org.elasticsearch'
 String upstreamVersion = '4.4.0'
-String localPrerelease = '1'
-version = "${upstreamVersion}-${localPrerelease}"
+
+if (System.getProperty("prerelease") != null) {
+  String localPrerelease = System.getProperty("prerelease")
+  version = "${upstreamVersion}-${localPrerelease}"
+} else {
+  version = upstreamVersion
+}
+
 String jnaDir = 'build/jna'
 String jarDir = 'build/jar'
 String pkgDir = 'com/sun/jna'

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ publishing {
         node.appendNode('name', 'Elastic JNA Distribution')
         node.appendNode('description',
           'A build of jna which supports all platforms supported by Elasticsearch')
+        node.appendNode('url', 'https://github.com/elastic/jna-build')
 
         Node license = node.appendNode('licenses').appendNode('license')
         license.appendNode('name', 'The Apache Software License, Version 2.0')

--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,7 @@ publishing {
         node.appendNode('name', 'Elastic JNA Distribution')
         node.appendNode('description',
           'A build of jna which supports all platforms supported by Elasticsearch')
-        node.appendNode('url', 'https://github.com/elastic/jna-build')
+        node.appendNode('url', 'https://github.com/java-native-access/jna')
 
         Node license = node.appendNode('licenses').appendNode('license')
         license.appendNode('name', 'The Apache Software License, Version 2.0')


### PR DESCRIPTION
In cases where we need to publish a new version of our JNA jar apart from upstream, we need a way to identify it from the last.  This implements a scheme similar to the way OS packages do it, where we add an ordinal after the major.minor.patch ("pre-release" in semver).