### PR TITLE
Fix "Apache License, Version 2.0" spelling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ publishing {
         node.appendNode('url', 'https://github.com/java-native-access/jna')
 
         Node license = node.appendNode('licenses').appendNode('license')
-        license.appendNode('name', 'The Apache Software License, Version 2.0')
+        license.appendNode('name', 'Apache License, Version 2.0')
         license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
         license.appendNode('distribution', 'repo')
 


### PR DESCRIPTION
There are many Java libraries licensed under "Apache License, Version 2.0" that do not use its official spelling.
This causes issues like https://issues.apache.org/jira/browse/MPIR-382: with every library defining its own spelling, it's difficult in large projects to have a clear view of all licenses in use.
This PR changes the license spelling to the official one, as advised by Maven developers.