### PR TITLE
Upgrade to upstream JNA 5.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 
 group = 'org.elasticsearch'
-String upstreamVersion = '5.5.0'
+String upstreamVersion = '5.7.0'
 
 // Rarely, modifications may need to be made to the jna jar that
 // aren't reflected in the upstream.  A suffix can be supplied to bump


### PR DESCRIPTION
This commit upgrades the JNA dependency to JNA 5.7.0. This enables us to pick up that the Darwin native libraries are now universal to include native functionality for both Intel-based and Apple Silicon-based Darwin platforms.